### PR TITLE
Rhtas trust config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All versions prior to 1.0.0 are untracked.
 - Added support trace sigstore sign and verify operations using OpenTelemetry.
 - cli: Added support for `--ignore_unsigned_files` option
 - Implemented a new, minimal container image. This variant excludes optional dependencies (like OTel and PKCS#11) to reduce footprint, focusing solely on core signing and verification mechanisms.
+- Added support for signing and verifying using private Sigstore instances (`--trust_config`)
+- By default (when `--trust_config` is not used) the whole trust configuration now comes from the TUF repository
 
 ## [1.0.1] - 2024-04-18
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,32 @@ This will open an OIDC flow to obtain a short lived token for the certificate.
 The identity used during signing and the provider must be reused during
 verification.
 
+## Using Private Sigstore Instances
+
+To use a private Sigstore setup (e.g. custom Rekor/Fulcio), use the `--trust_config` flag:
+
+```bash
+[...]$ model_signing sign bert-base-uncased --trust_config client_trust_config.json
+```
+
+For verification:
+
+```bash
+[...]$ model_signing verify bert-base-uncased \
+      --signature model.sig \
+      --trust_config client_trust_config.json
+      --identity "$identity"
+      --identity_provider "$oidc_provider"
+```
+
+The `client_trust_config.json` file should include:
+
+- A signed target trust root
+- A `signingConfig` section with your private Rekor, Fulcio, and CT log endpoints
+- Public keys for verification (if applicable)
+
+You can find an example `client_trust_config.json` [here](https://github.com/sigstore/sigstore-python/blob/main/test/assets/trust_config/config.v1.json).
+
 As another example, here is how we can sign with private keys. First, we
 generate the key pair:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "click",
   "cryptography",
   "in-toto-attestation",
-  "sigstore @ git+https://github.com/sigstore/sigstore-python.git@main",
+  "sigstore @ git+https://github.com/sigstore/sigstore-python.git@77c4b8c6",
   "typing_extensions",
 ]
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "click",
   "cryptography",
   "in-toto-attestation",
-  "sigstore",
+  "sigstore @ git+https://github.com/sigstore/sigstore-python.git@main",
   "typing_extensions",
 ]
 requires-python = ">=3.9"
@@ -75,6 +75,9 @@ path = "src/model_signing/__init__.py"
 
 [tool.hatch.build]
 packages = ["src/model_signing"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.envs.hatch-test]
 installer = "pip"

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -68,6 +68,14 @@ _read_signature_option = click.option(
     help="Location of the signature file to verify.",
 )
 
+# Decorator for the commonly used option for the custom trust configuration.
+_trust_config_option = click.option(
+    "--trust_config",
+    type=pathlib.Path,
+    metavar="TRUST_CONFIG_PATH",
+    help="The client trust configuration to use",
+)
+
 # Decorator for the commonly used option to ignore certain paths
 _ignore_paths_option = click.option(
     "--ignore-paths",
@@ -277,6 +285,7 @@ def _sign() -> None:
 @_allow_symlinks_option
 @_write_signature_option
 @_sigstore_staging_option
+@_trust_config_option
 @click.option(
     "--use_ambient_credentials",
     type=bool,
@@ -325,6 +334,7 @@ def _sign_sigstore(
     identity_token: Optional[str] = None,
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
+    trust_config: Optional[pathlib.Path] = None,
 ) -> None:
     """Sign using Sigstore (DEFAULT signing method).
 
@@ -341,6 +351,19 @@ def _sign_sigstore(
     Sigstore allows users to use a staging instance for test-only signatures.
     Passing the `--use_staging` flag would use that instance instead of the
     production one.
+
+    Additionally, you can specify a custom trust configuration JSON file using
+    the `--trust_config` flag. This allows you to fully customize the PKI
+    (Private Key Infrastructure) used in the signing process. By providing a
+    `--trust_config`, you can define your own transparency logs, certificate
+    authorities, and other trust settings, enabling full control over the
+    trust model, including which PKI to use for signature verification.
+
+    If `--trust_config` is not provided, the default Sigstore instance is
+    used, which is pre-configured with Sigstore’s own trusted transparency
+    logs and certificate authorities. This provides a ready-to-use default
+    trust model for most use cases but may not be suitable for custom or
+    highly regulated environments.
     """
     with tracer.start_as_current_span("Sign") as span:
         span.set_attribute("sigstore.sign_method", "sigstore")
@@ -361,6 +384,7 @@ def _sign_sigstore(
                 force_oob=oauth_force_oob,
                 client_id=client_id,
                 client_secret=client_secret,
+                trust_config=trust_config,
             ).set_hashing_config(
                 model_signing.hashing.Config()
                 .set_ignored_paths(
@@ -598,6 +622,12 @@ def _verify() -> None:
     signature is assumed to be generated via Sigstore (as if invoking `sigstore`
     subcommand).
 
+    To enable verification with custom PKI configurations, use the
+    `--trust_config` option. This allows you to specify your own set of trusted
+    public keys, transparency logs, and certificate authorities for verifying
+    the signature. If not provided, the default Sigstore instance and its
+    associated public keys, logs, and authorities are used.
+
     Use each subcommand's `--help` option for details on each mode.
     """
 
@@ -609,6 +639,7 @@ def _verify() -> None:
 @_ignore_git_paths_option
 @_allow_symlinks_option
 @_sigstore_staging_option
+@_trust_config_option
 @click.option(
     "--identity",
     type=str,
@@ -634,6 +665,7 @@ def _verify_sigstore(
     identity_provider: str,
     use_staging: bool,
     ignore_unsigned_files: bool,
+    trust_config: Optional[pathlib.Path] = None,
 ) -> None:
     """Verify using Sigstore (DEFAULT verification method).
 
@@ -660,6 +692,7 @@ def _verify_sigstore(
                 identity=identity,
                 oidc_issuer=identity_provider,
                 use_staging=use_staging,
+                trust_config=trust_config,
             ).set_hashing_config(
                 model_signing.hashing.Config()
                 .set_ignored_paths(

--- a/src/model_signing/_signing/sign_sigstore_pb.py
+++ b/src/model_signing/_signing/sign_sigstore_pb.py
@@ -111,8 +111,8 @@ class Signature(signing.Signature):
     @override
     def read(cls, path: pathlib.Path) -> Self:
         content = path.read_text()
-        parsed_dict = json.loads(content)
-        return cls(bundle_pb.Bundle().from_dict(parsed_dict))
+        inner = bundle_pb.Bundle.from_dict(json.loads(content))
+        return cls(inner)
 
 
 class Signer(signing.Signer):

--- a/src/model_signing/signing.py
+++ b/src/model_signing/signing.py
@@ -78,9 +78,13 @@ def sign(model_path: hashing.PathLike, signature_path: hashing.PathLike):
 class Config:
     """Configuration to use when signing models.
 
-    Currently we support signing with Sigstore (public instance and staging
-    instance), signing with private keys and signing with signing certificates.
-    Other signing modes can be added in the future.
+    Currently, we support signing with Sigstore (both the public
+    instance and staging instance), signing with private keys,
+    signing with signing certificates, and signing with custom
+    PKI configurations using the `--trust_config` option.
+    This allows users to bring their own trust configuration
+    to sign and verify models. Other signing modes may be
+    added in the future.
     """
 
     def __init__(self):
@@ -127,6 +131,7 @@ class Config:
         identity_token: Optional[str] = None,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
+        trust_config: Optional[pathlib.Path] = None,
     ) -> Self:
         """Configures the signing to be performed with Sigstore.
 
@@ -161,6 +166,12 @@ class Config:
               identity to the OIDC provider. If not provided, it is assumed
               that the client is public or the provider does not require a
               secret.
+            trust_config: A path to a custom trust configuration. When provided,
+              the signature verification process will rely on the supplied
+              PKI and trust configurations, instead of the default Sigstore
+              setup. If not specified, the default Sigstore configuration
+              is used.
+
 
         Return:
             The new signing configuration.
@@ -173,6 +184,7 @@ class Config:
             force_oob=force_oob,
             client_id=client_id,
             client_secret=client_secret,
+            trust_config=trust_config,
         )
         return self
 

--- a/src/model_signing/verifying.py
+++ b/src/model_signing/verifying.py
@@ -40,6 +40,7 @@ The API defined here is stable and backwards compatible.
 from collections.abc import Iterable
 import pathlib
 import sys
+from typing import Optional
 
 from model_signing import hashing
 from model_signing import manifest
@@ -210,7 +211,12 @@ class Config:
             raise ValueError("Cannot guess the hashing configuration")
 
     def use_sigstore_verifier(
-        self, *, identity: str, oidc_issuer: str, use_staging: bool = False
+        self,
+        *,
+        identity: str,
+        oidc_issuer: str,
+        use_staging: bool = False,
+        trust_config: Optional[pathlib.Path] = None,
     ) -> Self:
         """Configures the verification of signatures produced by Sigstore.
 
@@ -224,13 +230,21 @@ class Config:
               certificate used for the signature.
             use_staging: Use staging configurations, instead of production. This
               is supposed to be set to True only when testing. Default is False.
+            trust_config: A path to a custom trust configuration. When provided,
+              the signature verification process will rely on the supplied
+              PKI and trust configurations, instead of the default Sigstore
+              setup. If not specified, the default Sigstore configuration
+              is used.
 
         Return:
             The new verification configuration.
         """
         self._uses_sigstore = True
         self._verifier = sigstore.Verifier(
-            identity=identity, oidc_issuer=oidc_issuer, use_staging=use_staging
+            identity=identity,
+            oidc_issuer=oidc_issuer,
+            use_staging=use_staging,
+            trust_config=trust_config,
         )
         return self
 

--- a/tests/_signing/sigstore_test.py
+++ b/tests/_signing/sigstore_test.py
@@ -128,8 +128,7 @@ def mocked_sigstore_signer():
         mocked_context.signer.return_value = signer
 
         mocked_signing_context = mocked_objects["SigningContext"]
-        mocked_signing_context.staging.return_value = mocked_context
-        mocked_signing_context.production.return_value = mocked_context
+        mocked_signing_context.from_trust_config.return_value = mocked_context
 
         yield mocked_objects
 
@@ -140,8 +139,7 @@ def mocked_sigstore_verifier():
         sigstore.sigstore_verifier, "Verifier", autospec=True
     ) as mocked_verifier:
         mocked_verifier.verify_dsse = _mocked_verify_dsse
-        mocked_verifier.staging = lambda: mocked_verifier
-        mocked_verifier.production = lambda: mocked_verifier
+        mocked_verifier.return_value = mocked_verifier
         yield mocked_verifier
 
 
@@ -154,7 +152,7 @@ def mocked_sigstore_verifier_bad_payload():
         sigstore.sigstore_verifier, "Verifier", autospec=True
     ) as mocked_verifier:
         mocked_verifier.verify_dsse = _verify_dsse
-        mocked_verifier.staging = lambda: mocked_verifier
+        mocked_verifier.return_value = mocked_verifier
         yield mocked_verifier
 
 


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->

## Summary by Sourcery

Enable users to specify a custom PKI trust configuration for Sigstore-based signing and verification by adding a --trust_config option across the codebase, updating default trust handling, documentation, tests, and build settings.

New Features:
- Add support for custom trust configurations via --trust_config for Sigstore signing and verification

Enhancements:
- Propagate trust_config through Config, signer, and verifier to initialize contexts with ClientTrustConfig
- Switch default trust configuration source to the TUF repository when no custom config is provided

Build:
- Pin sigstore dependency to a specific git ref and enable direct references in pyproject.toml

Documentation:
- Document --trust_config usage and private Sigstore instance setup in the CLI help and README

Tests:
- Update Sigstore signer and verifier tests to mock from_trust_config and adapt to new initialization flow

Chores:
- Fix JSON parsing in sign_sigstore_pb.read() to use Bundle.from_dict