### PR TITLE
Enable codecov coverage checks

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,50 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Code Coverage
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+  push:
+    branches: [main]
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  coverage:
+    name: Upload code coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: go.mod
+    - name: Run tests with coverage
+      run: go test -v -coverprofile=coverage.out ./...
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+      with:
+        files: coverage.out
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 __pycache__/
 dist/
 html/
+coverage.out

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+    project:
+      default:
+        target: auto
+        informational: true


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`.github/workflows/code-coverage.yml`) that runs Go tests with coverage on every PR and push to `main`, then uploads the report to Codecov.
- Adds `codecov.yml` with coverage status thresholds:
  - **Patch coverage**: 70% target with 5% threshold — new/changed lines in a PR must maintain at least 70% coverage (with 5% tolerance).
  - **Project coverage**: auto target, informational only — tracks overall project coverage trend without blocking PRs.
- Adds `coverage.out` to `.gitignore` to keep the generated coverage artifact out of version control.

## Setup Required

`CODECOV_TOKEN` must be configured as a repository secret in GitHub. Without this token, the Codecov upload step will fail (`fail_ci_if_error: true`).

## Test Plan

- [ ] Verify the `Code Coverage` workflow triggers on PRs targeting `main`
- [ ] Verify `coverage.out` is listed in `.gitignore` and not tracked by git
- [ ] Verify Codecov receives the coverage report after a successful workflow run
- [ ] Verify Codecov PR status checks appear (patch and project)

Implements [SECURESIGN-4375](https://redhat.atlassian.net/browse/SECURESIGN-4375)