### PR TITLE
 chore: initialise model-transparency 1.0.1 release

### DIFF
--- a/.tekton/model-transparency-pull-request.yaml
+++ b/.tekton/model-transparency-pull-request.yaml
@@ -19,9 +19,9 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.4.1"
   - name: image-version
-    value: "1.0.0"
+    value: "1.0.1"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/model-transparency-push.yaml
+++ b/.tekton/model-transparency-push.yaml
@@ -18,9 +18,9 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.4.1"
   - name: image-version
-    value: "1.0.0"
+    value: "1.0.1"
   - name: git-url
     value: '{{source_url}}'
   - name: revision


### PR DESCRIPTION
  Bump release-version to 1.4.1 and image-version to 1.0.1 in
  Tekton push and pull-request pipelines.

<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
