### PR TITLE
fix: scope hatch packages directive to wheel target only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ PyPI = "https://pypi.org/project/rh-model-signing/"
 [tool.hatch.version]
 path = "src/model_signing/__init__.py"
 
-[tool.hatch.build]
+[tool.hatch.build.targets.wheel]
 packages = ["src/model_signing"]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
## Summary

- Moves `packages = ["src/model_signing"]` from `[tool.hatch.build]` to `[tool.hatch.build.targets.wheel]`
- Fixes sdist installs producing empty wheels with zero Python modules
- Root cause of the packaging failure worked around in [red-hat-data-services/model-registry#1305](https://github.com/red-hat-data-services/model-registry/pull/1305)

## Problem

The `packages` directive under `[tool.hatch.build]` applies to **both** wheel and sdist targets. Hatchling's sdist builder flattens the `src/` layout, placing `model_signing/` at the archive root — but the embedded `pyproject.toml` still references `packages = ["src/model_signing"]`. When pip installs from the sdist, hatch finds 0 files at that path and produces an empty wheel.

This affects Konflux hermetic builds (which install from sdists via cachi2).

## Fix

Scope the directive to `[tool.hatch.build.targets.wheel]` only. The sdist target then uses hatchling's default behavior - preserve the full source tree including the `src/` prefix - so the `packages` path matches the actual directory structure.

## Testing

- [x] `hatch build` produces both wheel and sdist
- [x] Install from sdist: 28 Python files (was 0)
- [x] Install from wheel: 28 Python files (unchanged)