### PR TITLE
fix: update codecov-action to v6.0.2 for GPG key fix

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+      uses: codecov/codecov-action@8cad3ba95e5920c42f44492e54bc9639cba47959 # v6.0.2
       with:
         files: coverage.xml
         flags: unit


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Update Codecov GitHub Action pin to v6.0.2 (GPG key fix)
<code>⚙️ Configuration changes</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Bump pinned Codecov GitHub Action to v6.0.2 to pick up GPG key fix.
• Keep coverage upload behavior unchanged (still only on Ubuntu + Python 3.12).
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Unit tests workflow"] --> B["Codecov action v6.0.2"] --> C{{"Codecov service"}}
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Pin by version tag (e.g., codecov/codecov-action@v6.0.2)</b></summary>

- ➕ Easier to read/maintain than raw commit SHA
- ➕ Simplifies future patch updates
- ➖ Less supply-chain strict than a full SHA pin
- ➖ Tag retargeting risk (even if unlikely)

</details>

<details>
<summary><b>2. Keep SHA pinning, add Dependabot updates for GitHub Actions</b></summary>

- ➕ Retains strongest pinning while automating update PRs
- ➕ Reduces time-to-patch for action security fixes
- ➖ Adds ongoing PR noise without careful scheduling/grouping

</details>

**Recommendation:** The current approach (updating the pinned SHA to the v6.0.2 commit) is appropriate for supply-chain safety while picking up the upstream GPG key fix. Consider adding Dependabot for GitHub Actions if you want to ensure timely future action security updates without manual tracking.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>unit_tests.yml</strong> <code>Bump Codecov action pin to v6.0.2</code> <code>+1/-1</code></summary>

<br/>

>Bump Codecov action pin to v6.0.2
>
><pre>
>• Updates the workflow step that uploads coverage to Codecov to use the v6.0.2 pinned commit SHA (instead of the prior v6 SHA) to incorporate the upstream GPG key fix. Execution conditions and inputs remain the same.
></pre>
>
><a href='https://github.com/securesign/model-transparency/pull/79/files#diff-c91058a32040621ac54d6ea4194b302a420b7849f6e8561920d23a0e97acf69a'>.github/workflows/unit_tests.yml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>