### PR TITLE
fix(deps): pin pip to 26.1.2

### DIFF
--- a/Dockerfile.model-transparency.rh
+++ b/Dockerfile.model-transparency.rh
@@ -1,13 +1,13 @@
-FROM registry.redhat.io/ubi9/python-312-minimal@sha256:ba0413d56e6ecfa5dda5996f1b797e3b2e7cc798849fb97d4c75c1cfd721f4de AS builder
+FROM registry.redhat.io/ubi9/python-312-minimal@sha256:2d921bf05fd43982a34f1cca91a37dd4a9952fdd1243f0f78ac82e12444d7cc8 AS builder
 
 WORKDIR /app
 COPY src /app/src
 COPY pyproject.toml /app/
 COPY README.md /app/
 COPY LICENSE /app/
-RUN pip install .
+RUN pip install pip==26.1.2 && pip install .
 
-FROM registry.redhat.io/ubi9/python-312-minimal@sha256:ba0413d56e6ecfa5dda5996f1b797e3b2e7cc798849fb97d4c75c1cfd721f4de
+FROM registry.redhat.io/ubi9/python-312-minimal@sha256:2d921bf05fd43982a34f1cca91a37dd4a9952fdd1243f0f78ac82e12444d7cc8
 
 COPY --from=builder /opt/app-root/bin /opt/app-root/bin
 COPY --from=builder /opt/app-root/lib64/python3.12/site-packages /opt/app-root/lib64/python3.12/site-packages


### PR DESCRIPTION
 - The UBI9 python-312-minimal base image ships pip 24.2 and there is a requirement to have pip atleast at version 26.1.2 to resolve CVE, hence  the pinned pip upgrade in DockerFile

<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
