### PR TITLE
chore(deps): bump pyasn1 to >=0.6.4 for CVE-2026-59886

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "cryptography>=46.0.7",
   "in-toto-attestation",
   "oras>=0.2.30",
-  "pyasn1>=0.6.2",
+  "pyasn1>=0.6.4",
   "sigstore>=4.2",
   "sigstore-models>=0.0.5",
   "typing_extensions",


### PR DESCRIPTION
## Summary
- Bumps `pyasn1` minimum version from 0.6.2 to 0.6.4

## CVEs Addressed
- **CVE-2026-59886** — pyasn1: DoS via crafted ASN.1 REAL values causing excessive memory/CPU
  - [SECURESIGN-5051](https://redhat.atlassian.net/browse/SECURESIGN-5051) (rhtas-1.4)
  - [SECURESIGN-5050](https://redhat.atlassian.net/browse/SECURESIGN-5050) (rhtas-1.3)

## Test plan
- [x] `pip install "pyasn1>=0.6.4"` installs v0.6.4 successfully
- [ ] CI pipeline passes

[SECURESIGN-5051]: https://redhat.atlassian.net/browse/SECURESIGN-5051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SECURESIGN-5050]: https://redhat.atlassian.net/browse/SECURESIGN-5050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ